### PR TITLE
disable auto-opening the browser tab

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,2 @@
 REACT_APP_API_HOST=host_backendu
+BROWSER=none

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "ctb-frontend",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@craco/craco": "^7.0.0",
         "@fontsource/roboto": "^4.5.8",


### PR DESCRIPTION
Disable auto-opening of the browser tab when running "npm run start" which is annoying.
It opens your default browser while you may want to open the website in different browser. 
On my system it doesn't pick the already open tab with the website, instead it opens new tab. 